### PR TITLE
fixed total app width, changed spacing between logos

### DIFF
--- a/app.ipynb
+++ b/app.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "size_opts_map = {} # dict(width=715, height=520), map is scaling size dynamically now\n",
+    "size_opts_map = dict(width=715, height=520)\n",
     "size_opts_his = dict(height=180, width=350)\n",
     "size_opts_bar = dict(height=45,  width=250)\n",
     "size_opts_slr = dict(height=300, width=120)\n",
@@ -521,20 +521,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oggm_logo = '<p style=\"margin-top: 0px;\"><a href=\"https://edu.oggm.org\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_edu.png\" width=180 height=79></a></p>'\n",
-    "fk_logo = '<a href=\"https://www.uibk.ac.at/foerderkreis1669/\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_1669.png\" width=180 height=79></a>'\n",
-    "unib_logo = '<a href=\"https://www.uni-bremen.de/\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_uni_bremen.png\" width=180 height=79></a>'\n",
-    "pn_logo = '<a href=\"https://panel.pyviz.org\"><img src=\"https://panel.pyviz.org/_static/logo_stacked.png\" width=46 height=39></a>'\n",
-    "holo_logo = '<a href=\"https://holoviz.org/\"><img src=\"https://raw.githubusercontent.com/pyviz/holoviews/master/doc/_static/logo.png\" width=46 height=39></a>'\n",
-    "dasha_logo = '<a href=\"https://datashader.org/\"><img src=\"https://raw.githubusercontent.com/pyviz/datashader/master/doc/_static/datashader-logo.png\" width=46 height=39></a>'\n",
+    "oggm_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://edu.oggm.org\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_edu.png\" width=180 height=79></a></p>'\n",
+    "fk_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://www.uibk.ac.at/foerderkreis1669/\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_1669.png\" width=180 height=79></a></p>'\n",
+    "unib_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://www.uni-bremen.de/\"><img src=\"https://raw.githubusercontent.com/OGGM/world-glacier-explorer/master/img/logo_uni_bremen.png\" width=130></a></p>'\n",
+    "pn_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://panel.pyviz.org\"><img src=\"https://panel.pyviz.org/_static/logo_stacked.png\" width=46 height=39></a></p>'\n",
+    "holo_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://holoviz.org/\"><img src=\"https://raw.githubusercontent.com/pyviz/holoviews/master/doc/_static/logo.png\" width=46 height=39></a></p>'\n",
+    "dasha_logo = '<p style=\"margin-top: 0px;margin-bottom: 0px;\"><a href=\"https://datashader.org/\"><img src=\"https://raw.githubusercontent.com/pyviz/datashader/master/doc/_static/datashader-logo.png\" width=46 height=39></a></p>'\n",
     "\n",
     "logos = pn.Row(pn.layout.Spacer(width=10), pn_logo, holo_logo, dasha_logo)\n",
     "\n",
-    "left = pn.Column(pn.Pane(oggm_logo), pn.layout.Spacer(sizing_mode='stretch_height', margin=(0, 0)),\n",
-    "                 pn.Pane(logos), pn.layout.Spacer(sizing_mode='stretch_height', margin=(0, 0)),\n",
-    "                 pn.Pane(fk_logo), pn.layout.Spacer(sizing_mode='stretch_height', margin=(0, 0)),\n",
-    "                 pn.Pane(unib_logo), pn.layout.Spacer(sizing_mode='stretch_height', margin=(0, 0)),\n",
-    "                 clear_button)"
+    "logos_height_spacer = 25\n",
+    "left = pn.Column(pn.Pane(oggm_logo, margin=(0, 0), align='center'), pn.layout.Spacer(height=logos_height_spacer, margin=(0, 0)),\n",
+    "                 pn.Pane(logos, margin=(0, 0), align='center'), pn.layout.Spacer(height=logos_height_spacer, margin=(0, 0)),\n",
+    "                 pn.Pane(fk_logo, margin=(0, 0), align='center'), pn.layout.Spacer(height=logos_height_spacer, margin=(0, 0)),\n",
+    "                 pn.Pane(unib_logo, margin=(0, 0), align='center', height=50), pn.layout.Spacer(height=logos_height_spacer, margin=(0, 0)),\n",
+    "                 clear_button, pn.layout.Spacer(sizing_mode='stretch_height', margin=(0, 0)))"
    ]
   },
   {
@@ -605,7 +606,7 @@
    "source": [
     "top = pn.Row(left, pn.Spacer(width=60, margin=(0, 0)),\n",
     "             overview, pn.Spacer(width=60, margin=(0, 0)), \n",
-    "             pn.Row(geomap.options(hooks=[geo_language], responsive=True,),\n",
+    "             pn.Row(geomap.options(hooks=[geo_language]),\n",
     "                    sizing_mode='stretch_both', margin=(0, 0)),\n",
     "             sizing_mode='stretch_both',\n",
     "             margin=(0, 0))"
@@ -624,7 +625,8 @@
     "                top,\n",
     "                plots,\n",
     "                explanation,\n",
-    "                sizing_mode='stretch_both')"
+    "                width=1465,\n",
+    "                )"
    ]
   },
   {


### PR DESCRIPTION
The trick decreasing the spacing between the logos is to include some HTML code to get rid of the default margin around the logos (`<p style="margin-top: 0px;margin-bottom: 0px;">`). Afterwards, you can change the spacing as you like.
You can adapt the spacing between the logos in the notebook with the variable `logos_height_spacer`.